### PR TITLE
change installation method from deprecated flag to new subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This solution in built on the [.NET 8 SDK](https://dotnet.microsoft.com/download
 This is a template and you can install it using the [dotnet new cli](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new).  To install the lastest version of the template run the following command.
 
 ``` bash
-dotnet new --install CleanMinimalApi.Template
+dotnet new install CleanMinimalApi.Template
 ```
 
 To create a new solution using this template run the following command


### PR DESCRIPTION
I got this warning while installing, seems like `--install` flag is deprecated and replacement is the `dotnet new install` subcomand.
![image](https://github.com/stphnwlsh/CleanMinimalApi/assets/41443083/0fce70d7-9d85-4cca-b79c-210edb94d912)

also using `8.0.101` version